### PR TITLE
Remove jaxb-core.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
 		<cxf.version>3.3.0</cxf.version>
 		<jaxb-api.version>3.0.1</jaxb-api.version>
 		<jaxb-imp.version>3.0.2</jaxb-imp.version>
-		<jaxb-core.version>2.3.0.1</jaxb-core.version> <!-- cxf -->
 		<junit-jupiter.version>5.9.0</junit-jupiter.version>
 		<junit-platform.version>1.9.0</junit-platform.version>
 		<maven.compiler.source>8</maven.compiler.source>


### PR DESCRIPTION
CXF devs at https://issues.apache.org/jira/browse/CXF-8371 think that the mere existence of `<jaxb-core.version>` indicates that JAXB 2.3 is still used in the project.

This PR should eliminate all doubt.